### PR TITLE
Button use click event

### DIFF
--- a/pkg/contrib/src/components/renderables/Button.ts
+++ b/pkg/contrib/src/components/renderables/Button.ts
@@ -24,7 +24,7 @@ export abstract class Button<T extends ButtonProps> extends Renderable<T> {
 
     this.initialStyle();
 
-    this.c.on("pointerdown", this._onClick);
+    this.c.on("click", this._onClick);
   }
 
   _onClick = () => {


### PR DESCRIPTION
was using `pointerdown`. according to a comment in this [thread](https://www.html5gamedevs.com/topic/31934-pointerdown-on-pixi-object-isnt-recognized-as-user-gesture/) mobile may work if using `click` instead

```
Looked at my code for this and indeed it seems click is the only event that works for full screen api across android and windows phones
```