### PR TITLE
debug mode improvements

### DIFF
--- a/core/src/contrib/entities/DebugButton.ts
+++ b/core/src/contrib/entities/DebugButton.ts
@@ -9,7 +9,7 @@ export const DebugButton = (): Entity => {
   const debugButton = {
     id: "debugButton",
     components: {
-      position: new Position({ x: 5, y: 5, screenFixed: true }),
+      position: new Position({ x: 40, y: 5, screenFixed: true }),
       clickable: new Clickable({
         width: 32,
         height: 32,

--- a/core/src/contrib/entities/FpsText.ts
+++ b/core/src/contrib/entities/FpsText.ts
@@ -8,7 +8,7 @@ export type FpsTextProps = {
   color?: number
 }
 
-export const FpsText = ({ x, y, color }: FpsTextProps = {}): Entity => {
+export const FpsText = ({ x, y, color }: FpsTextProps = {}): Entity<Position | Renderable> => {
   return {
     id: "fpsText",
     components: {

--- a/core/src/contrib/entities/FullscreenButton.ts
+++ b/core/src/contrib/entities/FullscreenButton.ts
@@ -6,7 +6,7 @@ export const FullscreenButton = (id: string = "fullscreenButton"): Entity => ({
   id: id,
   components: {
     position: new Position({
-      x: 40, y: 5, screenFixed: true
+      x: 5, y: 5, screenFixed: true
     }),
     clickable: new Clickable({
       active: true,

--- a/core/src/contrib/systems/DebugSystem.ts
+++ b/core/src/contrib/systems/DebugSystem.ts
@@ -1,4 +1,4 @@
-import { ColliderRJS, DebugBounds, Entity, Position, Renderable, SystemBuilder, TextBox, physics, worldToScreen } from "@piggo-legends/core";
+import { ColliderRJS, DebugBounds, Entity, FpsText, Position, Renderable, SystemBuilder, TextBox, physics, worldToScreen } from "@piggo-legends/core";
 import { Graphics, Text } from 'pixi.js';
 
 // DebugSystem adds visual debug information to renderered entities
@@ -22,6 +22,9 @@ export const DebugSystem: SystemBuilder = ({ world }) => {
 
       // draw all colliders
       if (!world.entities["collider-debug"]) drawAllColliders();
+
+      // draw the fps text
+      if (!world.entities["fpsText"]) drawFpsText();
 
       // update all debug entities
       Object.entries(debugEntitiesPerEntity).forEach(([id, debugEntities]) => {
@@ -83,6 +86,13 @@ export const DebugSystem: SystemBuilder = ({ world }) => {
     debugEntitiesPerEntity[entity.id].push(debugEntity);
     world.addEntity(debugEntity);
     debugRenderables.push(textBox, debugBounds);
+  }
+
+  const drawFpsText = () => {
+    // add to world
+    const fpsText = FpsText();
+    world.addEntity(fpsText);
+    debugEntitiesPerEntity["fpsText"] = [fpsText];
   }
 
   const drawAllColliders = () => {

--- a/core/src/contrib/systems/DebugSystem.ts
+++ b/core/src/contrib/systems/DebugSystem.ts
@@ -20,10 +20,10 @@ export const DebugSystem: SystemBuilder = ({ world }) => {
         }
       });
 
-      // TODO draws extra lines
       // draw all colliders
-      // if (!world.entities["collider-debug"]) drawAllColliders();
+      if (!world.entities["collider-debug"]) drawAllColliders();
 
+      // update all debug entities
       Object.entries(debugEntitiesPerEntity).forEach(([id, debugEntities]) => {
         const entity = world.entities[id] as Entity<Position>;
         if (entity) {
@@ -46,8 +46,7 @@ export const DebugSystem: SystemBuilder = ({ world }) => {
       });
       debugEntitiesPerEntity = {};
 
-      // cleanup all debug renderables
-      // debugRenderables.forEach((renderable) => renderable.cleanup());
+      // clear debug renderables
       debugRenderables = [];
     }
   }
@@ -95,7 +94,7 @@ export const DebugSystem: SystemBuilder = ({ world }) => {
           c.beginFill(0xffffff, 0.1).lineStyle(1, 0xffffff);
           const { vertices } = physics.debugRender();
 
-          for (let i = 0; i < vertices.length; i += 2) {
+          for (let i = 0; i < vertices.length; i += 4) {
             // use worldToScreen to convert the vertices to screen space
             const one = worldToScreen({ x: vertices[i], y: vertices[i + 1] });
             const two = worldToScreen({ x: vertices[i + 2], y: vertices[i + 3] });
@@ -126,10 +125,7 @@ export const DebugSystem: SystemBuilder = ({ world }) => {
 
     const r = new Renderable({
       dynamic: (c: Graphics) => {
-        if (c.clear) {
-          c.clear().beginFill(0xffffff, 0.1).lineStyle(1, 0xffffff);
-          // c.drawPolygon(...collider.body.vertices.map((v) => worldToScreen({ x: v.x - position.data.x, y: v.y - position.data.y })));
-        }
+        if (c.clear) c.clear().beginFill(0xffffff, 0.1).lineStyle(1, 0xffffff);
       },
       zIndex: 5,
       container: async () => new Graphics()

--- a/games/src/Playground.ts
+++ b/games/src/Playground.ts
@@ -1,5 +1,5 @@
 import {
-  Ball, Chat, ClickableSystem, CommandSystem, Cursor, DebugButton, DebugSystem, EnemySpawnSystem, FpsText,
+  Ball, Chat, ClickableSystem, CommandSystem, Cursor, DebugButton, DebugSystem, EnemySpawnSystem,
   FullscreenButton, GuiSystem, InputSystem, NPCSystem, Networked,
   PhysicsSystemRJS, PiggoWorld, Player, PlayerSpawnSystem, RenderSystem,
   SpaceBackground, TileFloor, Wall, World, WorldProps, WsClientSystem
@@ -21,7 +21,7 @@ export const Playground = (props: PlaygroundProps): World => {
     ]);
 
     // ui
-    world.addEntityBuilders([FpsText, FullscreenButton, DebugButton, Cursor, Chat]);
+    world.addEntityBuilders([FullscreenButton, DebugButton, Cursor, Chat]);
 
     // floor
     world.addEntity(TileFloor({ rows: 25, cols: 25, position: { x: 0, y: 0 } }));

--- a/games/src/Playground.ts
+++ b/games/src/Playground.ts
@@ -56,10 +56,10 @@ export const Playground = (props: PlaygroundProps): World => {
 
   // walls
   world.addEntities([
-    Wall({ x: 420, y: -20, length: 850, width: 1 }),
-    Wall({ x: 12, y: 380, length: 1, width: 850 }),
-    Wall({ x: 420, y: 780, length: 850, width: 1 }),
-    Wall({ x: 815, y: 380, length: 1, width: 850 })
+    Wall({ x: 420, y: -20, length: 420, width: 0 }),
+    Wall({ x: 12, y: 380, length: 0, width: 420 }),
+    Wall({ x: 420, y: 780, length: 420, width: 0 }),
+    Wall({ x: 815, y: 380, length: 0, width: 420 })
   ]);
 
   return world;

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -18,7 +18,7 @@ export const Header = () => {
         transform: 'translateY(-50%)',
       }}>
         <a target="_blank" href="https://github.com/alexanderclarktx/piggo-legends">
-          <FaGithub size={15} style={{ color: "white", marginTop: 6 }}></FaGithub>
+          <FaGithub size={20} style={{ color: "white", marginTop: 8 }}></FaGithub>
         </a>
       </div>
     </div>


### PR DESCRIPTION
when switching from matterJS to rapierJS, I had to disable drawing physics colliders in debug mode because it was showing extra lines. fixed the vertices iteration logic 🙏🏻

also, now only showing the fps text when in debug mode (confusing for non-technical players)

ref https://github.com/dimforge/rapier.js/issues/265

|before|after|
|--|--|
|![image](https://github.com/alexanderclarktx/piggo-legends/assets/9264428/92a08cd5-85cc-4d29-8650-14c27b73872f)|![Screenshot 2024-02-16 at 5 02 49 PM](https://github.com/alexanderclarktx/piggo-legends/assets/9264428/342a580c-a0d2-455b-88a8-13c637686c3f)
