### PR TITLE
title userSelect:none

### DIFF
--- a/core/src/contrib/systems/DebugSystem.ts
+++ b/core/src/contrib/systems/DebugSystem.ts
@@ -89,7 +89,6 @@ export const DebugSystem: SystemBuilder = ({ world }) => {
   }
 
   const drawFpsText = () => {
-    // add to world
     const fpsText = FpsText();
     world.addEntity(fpsText);
     debugEntitiesPerEntity["fpsText"] = [fpsText];

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -8,6 +8,7 @@ export const Header = () => {
       display: "flex",
       justifyContent: "center",
       alignItems: "center",
+      userSelect: "none",
       margin: 10
     }}>
       <h1 style={{ textAlign: "center", fontFamily: "Brush Script MT", margin: "0 10px" }}>Piggo Legends</h1>


### PR DESCRIPTION
players reported that the title was getting selected when they were clicking in the game. fixed by making the `<h1>Piggo Legends</h1>` not selectable